### PR TITLE
fix: make the http get request use TLS 1.3 to stop 403 errors.

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/jacopo-degattis/flacgo"
 )
@@ -84,6 +85,7 @@ func _request(path string, isPathOnly bool, params []QueryParams) (resp *http.Re
 
 	client := &http.Client{
 		Transport: transport,
+		Timeout:   30 * time.Second,
 	}
 
 	req, err := http.NewRequest(http.MethodGet, fullUrl, nil)


### PR DESCRIPTION
There was an issue that the default TLS version was not using 1.3 so Cloudflare was returning a 403.
Forcing the TLS version to be 1.3 fixes this error.