### PR TITLE
fix: use new dab music url

### DIFF
--- a/config/env.go
+++ b/config/env.go
@@ -12,7 +12,7 @@ func GetEndpoint() string {
 	if endpoint != "" {
 		return endpoint
 	}
-	return "https://dab.yeet.su"
+	return "https://dabmusic.xyz"
 }
 
 func GetDownloadLocation() string {


### PR DESCRIPTION
I know i just added this but they are changing the URL to this now.

This is the message in the discord:
> We’re moving off dab.yeet.su → please use https://dabmusic.xyz/ from now on!
The old domain will redirect, but update your links & scripts ASAP.
> superadmin0