### PR TITLE
feat(download): Implement retry logic for failed track dowloads and numbered track filenames

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .DS_Store
+*.md
+!README.md

--- a/api/album.go
+++ b/api/album.go
@@ -70,67 +70,89 @@ func (album *Album) downloadAlbum() error {
 	}
 
 	err := os.Mkdir(albumLocation, 0755)
-
 	if err != nil {
 		return fmt.Errorf("can't create dir %s", albumLocation)
 	}
 
 	bar := NewProgressBar(len(album.Tracks), "ALBUM", fmt.Sprintf("Downloading %s", album.Title), false)
-
-	// Force initial bar render
-	// bar.Add(1)
 	bar.RenderBlank()
 
-	maxConcurrent := 3
-	var wg sync.WaitGroup
-	sem := make(chan struct{}, maxConcurrent)
-	errChan := make(chan error, len(album.Tracks))
-	progressChan := make(chan int, len(album.Tracks)) // Channel for progress updates
-
+	progressChan := make(chan int, len(album.Tracks))
 	go func() {
 		for range progressChan {
 			bar.Add(1)
 		}
 	}()
 
-	for _, track := range album.Tracks {
-		wg.Add(1)
-		sem <- struct{}{}
-
-		go func(track Track) error {
-			defer wg.Done()
-			defer func() { <-sem }()
-
-			location := fmt.Sprintf("%s/%s.flac", albumLocation, SanitizeFilename(track.Title))
-			err = track.downloadTrack(location, false)
-
-			if err != nil {
-				errChan <- fmt.Errorf("%d", track.Id)
-			}
-
-			progressChan <- 1
-			time.Sleep(time.Millisecond)
-			time.Sleep(time.Duration(rand.Intn(1500)+500) * time.Millisecond)
-
-			return nil
-		}(track)
+	for i := range album.Tracks {
+		album.Tracks[i].TrackNumber = i + 1
 	}
 
-	go func() {
+	tracksToDownload := album.Tracks
+	var failedTracks []Track
+	maxRetries := 3
+	maxConcurrent := 3
+
+	for i := 0; i < maxRetries; i++ {
+		if len(tracksToDownload) == 0 {
+			break // All tracks downloaded successfully
+		}
+
+		if i > 0 {
+			PrintColor(COLOR_YELLOW, "\nRetrying %d failed tracks (attempt %d/%d)...\n", len(tracksToDownload), i+1, maxRetries)
+		}
+
+		var wg sync.WaitGroup
+		sem := make(chan struct{}, maxConcurrent)
+		failedTracksChan := make(chan Track, len(tracksToDownload))
+
+		for _, track := range tracksToDownload {
+			wg.Add(1)
+			sem <- struct{}{}
+
+			go func(track Track) {
+				defer wg.Done()
+				defer func() { <-sem }()
+
+				var trackName string
+				if track.TrackNumber < 10 {
+					trackName = fmt.Sprintf("0%d - %s", track.TrackNumber, SanitizeFilename(track.Title))
+				} else {
+					trackName = fmt.Sprintf("%d - %s", track.TrackNumber, SanitizeFilename(track.Title))
+				}
+
+				location := fmt.Sprintf("%s/%s.flac", albumLocation, trackName)
+				err := track.downloadTrack(location, false)
+
+				if err != nil {
+					failedTracksChan <- track
+				} else {
+					progressChan <- 1
+				}
+				time.Sleep(time.Duration(rand.Intn(1500)+500) * time.Millisecond)
+			}(track)
+		}
+
 		wg.Wait()
-		close(errChan)
-		close(progressChan)
-	}()
+		close(failedTracksChan)
 
-	var errors []error
-	for err := range errChan {
-		errors = append(errors, err)
+		failedTracks = nil // Reset the list for the current retry attempt
+		for failedTrack := range failedTracksChan {
+			failedTracks = append(failedTracks, failedTrack)
+		}
+
+		tracksToDownload = failedTracks
 	}
 
+	close(progressChan)
 	bar.Finish()
 
-	if len(errors) > 0 {
-		return fmt.Errorf("completed with %d errors: %v", len(errors), errors)
+	if len(failedTracks) > 0 {
+		var errorMessages []string
+		for _, track := range failedTracks {
+			errorMessages = append(errorMessages, fmt.Sprintf("'%s' (ID: %d)", track.Title, track.Id))
+		}
+		return fmt.Errorf("completed with %d errors. Failed to download tracks: %s", len(failedTracks), errorMessages)
 	}
 
 	return nil

--- a/api/api.go
+++ b/api/api.go
@@ -36,11 +36,12 @@ type QueryParams struct {
 }
 
 type Metadatas struct {
-	Title  string
-	Artist string
-	Album  string
-	Date   string
-	Cover  string
+	Title       string
+	Artist      string
+	Album       string
+	Date        string
+	Cover       string
+	TrackNumber int
 }
 
 // Support both album kind of track and single-track search

--- a/api/track.go
+++ b/api/track.go
@@ -18,6 +18,7 @@ type Track struct {
 	Cover       string `json:"albumCover"`
 	ReleaseDate string `json:"releaseDate"`
 	Duration    int    `json:"duration"`
+	TrackNumber int    `json:"-"`
 }
 
 func NewTrack(trackId string) (*Track, error) {
@@ -111,11 +112,12 @@ func (track *Track) downloadTrack(location string, withProgress bool) error {
 	}
 
 	err = _addMetadata(location, Metadatas{
-		Title:  track.Title,
-		Artist: track.Artist,
-		Album:  track.Album,
-		Date:   track.ReleaseDate,
-		Cover:  track.Cover,
+		Title:       track.Title,
+		Artist:      track.Artist,
+		Album:       track.Album,
+		Date:        track.ReleaseDate,
+		Cover:       track.Cover,
+		TrackNumber: track.TrackNumber,
 	})
 
 	if err != nil {


### PR DESCRIPTION


Refactors the album download process to be more resilient and user-friendly. The previous implementation would fail the entire album download if a single track failed and did not number the output files.

This change introduces:
- A retry mechanism that attempts to download failed tracks up to 3 times, making the process more robust against transient network errors.
- An improved final error message that lists the specific tracks that could not be downloaded after all retries.
- Track filenames are now prefixed with a zero-padded track number (e.g., `01 - Track Title.flac`) for proper sorting when an album is downloaded